### PR TITLE
refactor on deepEquals? (try it on your own first)

### DIFF
--- a/src/deepEquals.js
+++ b/src/deepEquals.js
@@ -1,58 +1,29 @@
 'use strict';
 
+// @NOTE: can be a separate file
 var isPrimitive = function (obj){
   return (
     typeof obj === 'boolean' ||
-    typeof obj === 'null' ||
-    typeof obj === 'undefined' ||
     typeof obj === 'number' ||
-    typeof obj === 'string'
+    typeof obj === 'string' ||
+    obj === undefined // no typeof needed
   );
 };
 
-var isSpecialObj = function (obj){
-  return (
-    NaN === obj ||
-    undefined === obj ||
-    null === obj
-  );
-};
-
-var deepEquals = function (o1, o2) {
-
-  if(isPrimitive(o1) || isSpecialObj(o1)){
+module.exports = function deepEquals(o1, o2) {
+  if (!o1 || !o2 || isPrimitive(o1)) {
     return o1 === o2;
-  }
-
-  if(!o2) {
-    return false;
   }
 
   var keys = Object.keys(o1);
   var len = keys.length;
 
-  for(var i=0; i<len; i++) {
-
+  for (var i = 0; i < len; i++) {
     var key = keys[i];
-    var value1 = o1[key];
-    var value2 = o2[key];
-
-    if(!o2.hasOwnProperty(key)) {
-      return false;
-    }
-
-    if(typeof value1 === 'object') {
-      var r = deepEquals(value1, value2);
-      if(!r){
-        return r;
-      }
-    } else if(value1 !== value2) {
+    if (!deepEquals(o1[key], o2[key])) {
       return false;
     }
   }
+
   return true;
 };
-
-module.exports = {
-  deepEquals: deepEquals
-}


### PR DESCRIPTION
Here's an implementation in ruby!

```rb
def deep_equal?(a, b)
  return true if a.nil? && b.nil?
  return false if a.nil? || b.nil?
  return false a.class != b.class
  if a.is_a? Array
    return false unless a.length == b.length
    for i in 0..(a.length)
      return false unless deep_equal?(a[i], b[i])
    end
    return true
  else a.is_a? Hash
    return false unless a.length == b.length
    return false unless deep_equal?(a.keys, b.keys)
    a.keys.each do |k|
      return false unless deep_equal(a[k], b[k])
    end  
    return true
  else
    return a == b
  end
end
```